### PR TITLE
For PEP8 we need an extra space around the VariableType class.

### DIFF
--- a/tests/resources/generator/algebraic_eqn_computed_var_on_rhs/code.py
+++ b/tests/resources/generator/algebraic_eqn_computed_var_on_rhs/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 0
 VARIABLE_COUNT = 2
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "", "units": "", "component": ""}
 

--- a/tests/resources/generator/algebraic_eqn_const_var_on_rhs/code.py
+++ b/tests/resources/generator/algebraic_eqn_const_var_on_rhs/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 0
 VARIABLE_COUNT = 2
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "", "units": "", "component": ""}
 

--- a/tests/resources/generator/algebraic_eqn_constant_on_rhs/code.py
+++ b/tests/resources/generator/algebraic_eqn_constant_on_rhs/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 0
 VARIABLE_COUNT = 1
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "", "units": "", "component": ""}
 

--- a/tests/resources/generator/algebraic_eqn_derivative_on_rhs/code.py
+++ b/tests/resources/generator/algebraic_eqn_derivative_on_rhs/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 1
 VARIABLE_COUNT = 2
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_ode"}
 

--- a/tests/resources/generator/algebraic_eqn_derivative_on_rhs_one_component/code.py
+++ b/tests/resources/generator/algebraic_eqn_derivative_on_rhs_one_component/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 1
 VARIABLE_COUNT = 2
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_component"}
 

--- a/tests/resources/generator/algebraic_eqn_state_var_on_rhs/code.py
+++ b/tests/resources/generator/algebraic_eqn_state_var_on_rhs/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 1
 VARIABLE_COUNT = 2
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_ode"}
 

--- a/tests/resources/generator/algebraic_eqn_state_var_on_rhs_one_component/code.py
+++ b/tests/resources/generator/algebraic_eqn_state_var_on_rhs_one_component/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 1
 VARIABLE_COUNT = 2
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_model"}
 

--- a/tests/resources/generator/cellml_mappings_and_encapsulations/code.py
+++ b/tests/resources/generator/cellml_mappings_and_encapsulations/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 2
 VARIABLE_COUNT = 2
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "ms", "component": "circle_x"}
 

--- a/tests/resources/generator/coverage/code.py
+++ b/tests/resources/generator/coverage/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 1
 VARIABLE_COUNT = 186
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_component"}
 

--- a/tests/resources/generator/dependent_eqns/code.py
+++ b/tests/resources/generator/dependent_eqns/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 1
 VARIABLE_COUNT = 2
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "time", "units": "second", "component": "my_component"}
 

--- a/tests/resources/generator/fabbri_fantini_wilders_severi_human_san_model_2017/code.py
+++ b/tests/resources/generator/fabbri_fantini_wilders_severi_human_san_model_2017/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 33
 VARIABLE_COUNT = 217
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "time", "units": "second", "component": "Nai_concentration"}
 

--- a/tests/resources/generator/garny_kohl_hunter_boyett_noble_rabbit_san_model_2003/code.py
+++ b/tests/resources/generator/garny_kohl_hunter_boyett_noble_rabbit_san_model_2003/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 15
 VARIABLE_COUNT = 185
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "time", "units": "second", "component": "membrane"}
 

--- a/tests/resources/generator/hodgkin_huxley_squid_axon_model_1952/code.py
+++ b/tests/resources/generator/hodgkin_huxley_squid_axon_model_1952/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 4
 VARIABLE_COUNT = 18
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "time", "units": "millisecond", "component": "membrane"}
 

--- a/tests/resources/generator/noble_model_1962/code.py
+++ b/tests/resources/generator/noble_model_1962/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 4
 VARIABLE_COUNT = 17
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "time", "units": "millisecond", "component": "membrane"}
 

--- a/tests/resources/generator/ode_computed_var_on_rhs/code.py
+++ b/tests/resources/generator/ode_computed_var_on_rhs/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 1
 VARIABLE_COUNT = 1
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_ode"}
 

--- a/tests/resources/generator/ode_computed_var_on_rhs_one_component/code.py
+++ b/tests/resources/generator/ode_computed_var_on_rhs_one_component/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 1
 VARIABLE_COUNT = 1
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_component"}
 

--- a/tests/resources/generator/ode_const_var_on_rhs/code.py
+++ b/tests/resources/generator/ode_const_var_on_rhs/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 1
 VARIABLE_COUNT = 1
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_ode"}
 

--- a/tests/resources/generator/ode_const_var_on_rhs_one_component/code.py
+++ b/tests/resources/generator/ode_const_var_on_rhs_one_component/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 1
 VARIABLE_COUNT = 1
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_component"}
 

--- a/tests/resources/generator/ode_constant_on_rhs/code.py
+++ b/tests/resources/generator/ode_constant_on_rhs/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 1
 VARIABLE_COUNT = 0
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_ode"}
 

--- a/tests/resources/generator/ode_constant_on_rhs_one_component/code.py
+++ b/tests/resources/generator/ode_constant_on_rhs_one_component/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 1
 VARIABLE_COUNT = 0
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_component"}
 

--- a/tests/resources/generator/ode_multiple_dependent_odes/code.py
+++ b/tests/resources/generator/ode_multiple_dependent_odes/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 2
 VARIABLE_COUNT = 1
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_x_ode"}
 

--- a/tests/resources/generator/ode_multiple_dependent_odes_one_component/code.py
+++ b/tests/resources/generator/ode_multiple_dependent_odes_one_component/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 2
 VARIABLE_COUNT = 1
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_component"}
 

--- a/tests/resources/generator/ode_multiple_odes_with_same_name/code.py
+++ b/tests/resources/generator/ode_multiple_odes_with_same_name/code.py
@@ -9,10 +9,12 @@ LIBCELLML_VERSION = "0.2.0"
 STATE_COUNT = 2
 VARIABLE_COUNT = 1
 
+
 class VariableType(Enum):
     CONSTANT = 1
     COMPUTED_CONSTANT = 2
     ALGEBRAIC = 3
+
 
 VOI_INFO = {"name": "t", "units": "second", "component": "my_first_ode"}
 


### PR DESCRIPTION
Gotta keep PEP8 happy.